### PR TITLE
feat(frontend): handle subsequent voice inputs for chat

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,9 +4,15 @@ import { useState, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 export default function Home() {
   const [isRecording, setIsRecording] = useState(false);
-  const [serverResponse, setServerResponse] = useState<{ markdown: string } | null>(null);
+  const [investigationResult, setInvestigationResult] = useState<string | null>(null);
+  const [conversationHistory, setConversationHistory] = useState<Message[]>([]);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
 
@@ -20,7 +26,6 @@ export default function Home() {
       mediaRecorderRef.current.onstop = handleSendAudio;
       mediaRecorderRef.current.start();
       setIsRecording(true);
-      setServerResponse(null);
     } catch (error) {
       console.error('Error accessing microphone:', error);
       alert('Could not access microphone. Please check permissions.');
@@ -40,49 +45,93 @@ export default function Home() {
     formData.append('audio', audioBlob, 'recording.webm');
 
     try {
-      const response = await fetch('http://localhost:3001/api/speech', {
+      // First, always transcribe the audio
+      const transcriptionResponse = await fetch('http://localhost:3001/api/speech', {
         method: 'POST',
         body: formData,
       });
-      const data = await response.json();
-      setServerResponse(data);
+      const transcriptionData = await transcriptionResponse.json();
+      const userMessageContent = transcriptionData.markdown; // Assuming the same key for now
+
+      const userMessage: Message = { role: 'user', content: userMessageContent };
+      setConversationHistory(prev => [...prev, userMessage]);
+
+      // If it's the first message, get the investigation document
+      if (!investigationResult) {
+        setInvestigationResult(userMessageContent);
+        // In a real scenario, the investigation would be a separate step.
+        // For now, we'll just use the transcribed text as the investigation result.
+      } else {
+        // For subsequent messages, call the chat endpoint
+        const chatResponse = await fetch('http://localhost:3001/api/chat', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            newMessage: userMessage,
+            history: conversationHistory,
+            contextDocument: investigationResult,
+          }),
+        });
+        const chatData = await chatResponse.json();
+        const assistantMessage: Message = { role: 'assistant', content: chatData.response };
+        setConversationHistory(prev => [...prev, assistantMessage]);
+      }
+
     } catch (error) {
-      console.error('Error sending audio:', error);
-      alert('Failed to send audio to server.');
+      console.error('Error during audio processing:', error);
+      alert('Failed to process audio.');
     }
 
     audioChunksRef.current = [];
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+    <div className="flex flex-col items-center min-h-screen bg-gray-100 p-4">
       <h1 className="text-4xl font-bold mb-8">Voice Discussion PoC</h1>
-      <div className="space-x-4">
-        <button
-          onClick={handleStartRecording}
-          disabled={isRecording}
-          className="px-6 py-3 bg-blue-500 text-white rounded-md disabled:bg-gray-400"
-        >
-          Start Recording
-        </button>
-        <button
-          onClick={handleStopRecording}
-          disabled={!isRecording}
-          className="px-6 py-3 bg-red-500 text-white rounded-md disabled:bg-gray-400"
-        >
-          Stop Recording
-        </button>
-      </div>
-      {serverResponse && serverResponse.markdown && (
-        <div className="mt-8 p-6 bg-white rounded-md shadow-md w-full max-w-4xl">
-          <h2 className="text-2xl font-semibold mb-4">Investigation Results:</h2>
-          <article className="prose lg:prose-xl">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {serverResponse.markdown}
-            </ReactMarkdown>
-          </article>
+      <div className="w-full max-w-4xl">
+        <div className="space-x-4 text-center mb-4">
+          <button
+            onClick={handleStartRecording}
+            disabled={isRecording}
+            className="px-6 py-3 bg-blue-500 text-white rounded-md disabled:bg-gray-400"
+          >
+            Start Recording
+          </button>
+          <button
+            onClick={handleStopRecording}
+            disabled={!isRecording}
+            className="px-6 py-3 bg-red-500 text-white rounded-md disabled:bg-gray-400"
+          >
+            Stop Recording
+          </button>
         </div>
-      )}
+        <div className="flex gap-4">
+          {investigationResult && (
+            <div className="w-1/2 p-6 bg-white rounded-md shadow-md">
+              <h2 className="text-2xl font-semibold mb-4">Investigation Results:</h2>
+              <article className="prose lg:prose-xl">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {investigationResult}
+                </ReactMarkdown>
+              </article>
+            </div>
+          )}
+          <div className={`w-${investigationResult ? '1/2' : 'full'} p-6 bg-white rounded-md shadow-md`}>
+            <h2 className="text-2xl font-semibold mb-4">Conversation:</h2>
+            <div className="space-y-4">
+              {conversationHistory.map((msg, index) => (
+                <div key={index} className={`p-3 rounded-lg ${msg.role === 'user' ? 'bg-blue-100 text-right' : 'bg-gray-200'}`}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {msg.content}
+                  </ReactMarkdown>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This commit implements the logic for handling the conversational loop on the frontend, fulfilling the requirements of Issue #10.

- Refactors the main page component to manage conversation history.
- After the initial investigation, subsequent audio is transcribed and then sent to the `/api/chat` endpoint along with the history.
- The AI's response is received and added to the conversation history.
- The UI is updated to display the ongoing conversation.

Closes #10